### PR TITLE
[GITHUB-3] Fixes APT install for Bionic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ sansible_newrelic_agent_php_appname: default
 sansible_newrelic_agent_php_appname_prefix: ""
 sansible_newrelic_agent_php_apt_key_id: 548C16BF
 sansible_newrelic_agent_php_apt_repo: "deb http://apt.newrelic.com/debian/ newrelic non-free"
+sansible_newrelic_agent_php_apt_repo_keyserver: keyserver.ubuntu.com
 sansible_newrelic_agent_php_display_name: "{{ ansible_hostname }}"
 sansible_newrelic_agent_php_start_on_boot: yes
 sansible_newrelic_agent_php_ini_config: []  # List of hashes: [ { option: some_option, section: some_section, value: some_value } ]

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,20 +11,28 @@
   register: sansible_newrelic_agent_php_deps_result
   until: sansible_newrelic_agent_php_deps_result is succeeded
 
-- name: Ensure New Relic PHP PGP key is known to the server
+- name: Download New Relic PHP PGP key (works with Bionic behind a proxy)
   become: yes
-  apt_key:
-    id: "{{ sansible_newrelic_agent_php_apt_key_id }}"
-    keyserver: hkp://keyserver.ubuntu.com:80
-    state: present
+  get_url:
+    dest: /usr/local/src/newrelic_php.asc
+    mode: 0644
+    url: "https://{{ sansible_newrelic_agent_php_apt_repo_keyserver }}/pks/lookup?op=get&search=0x{{ sansible_newrelic_agent_php_apt_key_id }}"
   retries: 2
   register: sansible_newrelic_agent_php_apt_key_result
   until: sansible_newrelic_agent_php_apt_key_result is succeeded
 
-- name: Add New Relic PHP APT repository
+- name: Ensures New Relic PHP PGP key is known
+  become: yes
+  apt_key:
+    file: /usr/local/src/newrelic_php.asc
+    id: "{{ sansible_newrelic_agent_php_apt_key_id }}"
+    state: present
+
+- name: Add New Relic PHP Repo
   become: yes
   apt_repository:
     repo: "{{ sansible_newrelic_agent_php_apt_repo }}"
+    state: present
     update_cache: yes
 
 - name: Install New Relic PHP agent


### PR DESCRIPTION
Switches to downloading key directly to get around proxy issues
with apt key when running on Bionic.